### PR TITLE
Fix local-wgs1 benchmark

### DIFF
--- a/benchmarks/local-wgs1/benchmark.json
+++ b/benchmarks/local-wgs1/benchmark.json
@@ -6,7 +6,7 @@
 "reference_fasta_is_partial": "true",
 
 "patients": {
-    "AOCS-034": {
+    "PT1": {
         "loci": "$AUTOSOMAL_LOCI_WITH_CHR_PREFIXES",
         "reads": {
             "normal": {

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     install_requires=[
         "varcode",
         "varlens",
+        "pyensembl",
         "nose>=1.3.1",
         "typechecks>=0.0.2",
         "pandas>=0.16.1",

--- a/variant_calling_benchmarks/joint_caller.py
+++ b/variant_calling_benchmarks/joint_caller.py
@@ -9,6 +9,7 @@ import numpy
 
 import varlens
 import varlens.variants_util
+from pyensembl.locus import normalize_chromosome
 
 from . import temp_files
 
@@ -125,6 +126,10 @@ def merge_calls_with_others(config, guacamole_calls_df):
 
     for (name, info) in config['variants'].items():
         df = pandas.read_csv(info.get_substituted('path', path=True))
+
+        # Since we load guacamole VCFs with varcode, the contigs will be
+        # normalized, so we have to normalize them here.
+        df["contig"] = df.contig.map(normalize_chromosome)
         df["called_%s" % name] = True
         merged = pandas.merge(
             merged,

--- a/variant_calling_benchmarks/temp_files.py
+++ b/variant_calling_benchmarks/temp_files.py
@@ -23,9 +23,11 @@ def finished(delete=True):
 
     Call this when the process is finishing.
     '''
+    global TEMPORARY_FILES
     for filename in TEMPORARY_FILES:
         if delete:
             print("Deleting: %s" % filename)
             os.unlink(filename)
         else:
             print("Not deleting: %s" % filename)
+        TEMPORARY_FILES = []


### PR DESCRIPTION
Turns out #13 was due to a mismatch between contig names. When we load a VCF with varcode, it automatically removes the 'chr' prefix.

* Normalize chromosome name when merging variants
* Fix local-wgs1 benchmark patient id

Closes #13.