### PR TITLE
Better configuration system, configurable `spark-submit` and env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,21 @@ TMPDIR=$(pwd)/tmp vcb-guacamole-cluster \
     --out-dir results
 ```
 
-## Submitting results to google cloud storage
+## Submitting results to google cloud storage (Hammer Lab users only)
 
-We're using Google Cloud Storage to store benchmark results. First, install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/).
+We're using Google Cloud Storage to store benchmark results. First, install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/) and login.
 
 After you've run a benchmark you can copy the results to GCS with a command like:
 
 ```
 gsutil rsync -d results gs://variant-calling-benchmarks-results/tim-$(date +"%m-%d-%y")
 ```
+
+You can also pull down all submitted benchmarks to your local machine with a command like:
+
+```
+gsutil -m rsync -r \
+    gs://variant-calling-benchmarks-results \
+    ~/sinai/data/gcs/variant-calling-benchmarks-results
+```
+

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Also checkout and build guacamole.
 
 The benchmark defintions and guacamole configurations are given in JSON. They are split into multiple files for clarity but the 'configuration' is just the union of all the files passed. The code doesn't care what the files are or which file has a particular property.
 
-A simple substitution mechanism is supported where strings like "foo-${NAME}" will have $NAME expanded according to substitutions defined in the config files (under the 'substitutions' keys). The special substitution `THIS_DIR` is the directory the JSON file is found in.
+A simple substitution mechanism is supported where strings like "foo-${NAME}" will have $NAME expanded according to substitutions defined in the config files (under the 'substitutions' keys). The variable `$THIS_DIR` always expands to the absolute path of the directory the current JSON file is found in.
 
 ## Benchmark definition
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Also checkout and build guacamole.
 
 The benchmark defintions and guacamole configurations are given in JSON. They are split into multiple files for clarity but the 'configuration' is just the union of all the files passed. The code doesn't care what the files are or which file has a particular property.
 
-Paths in config files are relative to the directory of the config file. A simple substitution mechanism is supported where strings like "foo-${NAME}" will have $NAME expanded according to substitutions defined in the config files (under the 'substitutions' keys).
+A simple substitution mechanism is supported where strings like "foo-${NAME}" will have $NAME expanded according to substitutions defined in the config files (under the 'substitutions' keys). The special substitution `THIS_DIR` is the directory the JSON file is found in.
 
 ## Benchmark definition
 

--- a/benchmarks/aocs/benchmark.json
+++ b/benchmarks/aocs/benchmark.json
@@ -30,7 +30,7 @@
 "variants": {
     "published": {
         "kind": "somatic",
-        "path": "aocs_published_calls.csv"
+        "path": "$THIS_DIR/aocs_published_calls.csv"
     }
 }
 

--- a/benchmarks/dream-challenge/benchmark.json
+++ b/benchmarks/dream-challenge/benchmark.json
@@ -24,7 +24,7 @@
 "variants" : {
     "published": {
         "kind": "somatic",
-        "path": "synthetic.challenge.set1.tumor.all.truth.vcf"
+        "path": "$THIS_DIR/synthetic.challenge.set1.tumor.all.truth.vcf"
     }
 }
 

--- a/benchmarks/local-wgs1/benchmark.json
+++ b/benchmarks/local-wgs1/benchmark.json
@@ -2,7 +2,7 @@
 "benchmark": "local-wgs1",
 "benchmark_description": "Runs locally using BAMs checked into the repo, which were copied from guacamole tests",
 
-"reference": "hg19.partial.fasta",
+"reference": "$THIS_DIR/hg19.partial.fasta",
 "reference_fasta_is_partial": "true",
 
 "patients": {
@@ -12,17 +12,17 @@
             "normal": {
                 "analyte": "dna",
                 "tissue_type": "normal",
-                "path": "normal.bam"
+                "path": "$THIS_DIR/normal.bam"
             },
             "primary": {
                 "analyte": "dna",
                 "tissue_type": "tumor",
-                "path": "primary.bam"
+                "path": "$THIS_DIR/primary.bam"
             },
             "recurrence": {
                 "analyte": "dna",
                 "tissue_type": "tumor",
-                "path": "recurrence.bam"
+                "path": "$THIS_DIR/recurrence.bam"
             }
         }
     }
@@ -30,7 +30,7 @@
 "variants": {
     "published": {
         "kind": "somatic",
-        "path": "published_calls.csv"
+        "path": "$THIS_DIR/published_calls.csv"
     }
 }
 

--- a/infrastructure-configs/demeter.json
+++ b/infrastructure-configs/demeter.json
@@ -17,8 +17,7 @@
     "--deploy-mode", "cluster",
     "--master", "yarn",
     "--executor-cores", "6",
-    "--executor-memory", "17g",
-    "--driver-memory", "10g",
+    "--driver-memory", "30g",
 
     "--conf", "spark.driver.maxResultSize=0",
     "--conf", "spark.yarn.executor.memoryOverhead=6000",
@@ -26,7 +25,6 @@
     "--conf", "spark.default.parallelism=10000",
     "--conf", "spark.eventLog.enabled=true",
     "--conf", "spark.eventLog.dir=hdfs://demeter-nn1.demeter.hpc.mssm.edu:/user/spark/applicationHistory",
-    "--conf", "spark.storage.memoryFraction=0.1",
     "--conf", "spark.shuffle.service.enabled=true",
     "--conf", "spark.speculation=true",
     "--conf", "spark.speculation.interval=1000",

--- a/infrastructure-configs/demeter.json
+++ b/infrastructure-configs/demeter.json
@@ -2,8 +2,16 @@
 
 "substitutions": {
     "AOCS_HDFS_BAMS": "hdfs:///datasets/ovarian/ega-tim",
-    "HG19_FASTA": "/hpc/users/ahujaa01/reference_genomes/hg19-reference/ucsc.hg19.fasta"
+    "HG19_FASTA": "/hpc/users/ahujaa01/reference_genomes/hg19-reference/ucsc.hg19.fasta",
+    "SPARK_HOME": "/hpc/users/willir31/sparks/spark-1.6.1-bin-hadoop2.6"
 },
+
+"environment_variables": {
+    "SPARK_HOME": "$SPARK_HOME",
+    "YARN_CONF_DIR": "/etc/hadoop/conf"
+},
+
+"spark_submit": "$SPARK_HOME/bin/spark-submit",
 
 "spark_submit_arguments": [
     "--deploy-mode", "cluster",

--- a/variant_calling_benchmarks/config.py
+++ b/variant_calling_benchmarks/config.py
@@ -6,6 +6,27 @@ import functools
 import pprint
 
 def substitute(value, variables, raise_on_keyerror=True):
+    """
+    Interpolate a string like "Hello $NAME" in the context of the given
+    variables (like: {"NAME": "John"}.
+
+    The substition values may themselves have substitutions. The interpolation
+    is run repeatedly until a fixed point is reached.
+
+    Parameters
+    -----------
+    value : string
+        The string to be substituted
+
+    variables : dict
+        The variables to substitute
+
+    raise_on_keyerror : boolean
+        If True, a KeyError is raised if a substitution is not found in
+        variables. If False, the substitution is left in the string and no
+        error is raised.
+
+    """
     result = None
     original = value
     i = 0
@@ -26,6 +47,10 @@ def substitute(value, variables, raise_on_keyerror=True):
     return result
 
 def recursive_substitute(node, variables, raise_on_keyerror=True):
+    """
+    Substitute strings recursively in a data structure of dicts, lists, and
+    strings.
+    """
     return recursive_map(
         node, functools.partial(
             substitute,
@@ -33,6 +58,10 @@ def recursive_substitute(node, variables, raise_on_keyerror=True):
             variables=variables))
 
 def recursive_map(node, function):
+    """
+    Run the given function on strings in a data structure of dicts, lists,
+    and strings, and return the result.
+    """
     if isinstance(node, dict):
         return dict(
             (key, recursive_map(value, function))
@@ -55,6 +84,9 @@ def load_config(*filenames):
         try:
             with open(filename) as fd:
                 d = json.load(fd)
+
+                # We substitute the special THIS_DIR substitution immediately,
+                # since its value depends on the filename.
                 d = recursive_substitute(d, {
                     'THIS_DIR': os.path.dirname(filename)
                 }, raise_on_keyerror=False)

--- a/variant_calling_benchmarks/config.py
+++ b/variant_calling_benchmarks/config.py
@@ -2,95 +2,72 @@ import os
 import logging
 import string
 import json
+import functools
+import pprint
 
-from six.moves.urllib.parse import urlparse
+def substitute(value, variables, raise_on_keyerror=True):
+    result = None
+    original = value
+    i = 0
+    while True:
+        template = string.Template(original)
+        if raise_on_keyerror:
+            result = template.substitute(**variables)
+        else:
+            result = template.safe_substitute(**variables)
+        if result == original:
+            # No changes.
+            break
+        original = result
+        if i > 100:
+            raise RuntimeError(
+                "Substitution not terminating: %s" % value)
+        i += 1
+    return result
+
+def recursive_substitute(node, variables, raise_on_keyerror=True):
+    return recursive_map(
+        node, functools.partial(
+            substitute,
+            raise_on_keyerror=raise_on_keyerror,
+            variables=variables))
+
+def recursive_map(node, function):
+    if isinstance(node, dict):
+        return dict(
+            (key, recursive_map(value, function))
+            for (key, value) in node.items())
+    if isinstance(node, list):
+        return [recursive_map(value, function) for value in node]
+    return function(node)
 
 def load_config(*filenames):
     '''
-    Load the specified JSON config files.
+    Load, merge, and interpolate the specified JSON config files.
 
     Returns
     ---------
-    MergedConfigDicts
+    dict
     '''
-    dicts = []
     substitutions = {}
+    merged = {}
     for filename in filenames:
         try:
-            def object_hook(dictionary):
-                return ConfigDict(filename, substitutions, dictionary)
-
             with open(filename) as fd:
-                d = json.load(fd, object_hook=object_hook)
+                d = json.load(fd)
+                d = recursive_substitute(d, {
+                    'THIS_DIR': os.path.dirname(filename)
+                }, raise_on_keyerror=False)
                 substitutions.update(d.get("substitutions", {}))
-                dicts.append(d)
+                merged.update(d)
         except Exception as e:
             logging.warn(
                 "Error loading config %s: %s" % (filename, str(e)))
             raise
 
-    return MergedConfigDicts(dicts)
+    substituted = recursive_substitute(merged, substitutions)
+    logging.info("Loaded config from files %s:\n%s" % (
+        " ".join(filenames),
+        pprint.pformat(substituted)))
 
-class MergedConfigDicts(dict):
-    '''
-
-    '''
-    def __init__(self, dicts):
-        self.key_to_dict = {}
-        for d in dicts:
-            self.update(d)
-            for key in d.keys():
-                self.key_to_dict[key] = d
-
-    def get_substituted(self, key, path=False):
-        return self.key_to_dict[key].get_substituted(key, path=path)
-
-class ConfigDict(dict):
-    '''
-    Thin wrapper over a dict that adds the get_substituted method.
-    '''
-    def __init__(self, filename, substitutions, dictionary):
-        '''
-        Parameters
-        -------------
-        filename : string
-            File this dict was loaded from.
-
-        substitutions : dict
-            String substitutions that should be used when get_substituted
-            is called.
-
-        dictionary : dict
-            The dictionary to be wrapped.
-        '''
-        self.filename = filename
-        self.substitutions = substitutions
-        self.basedir = os.path.dirname(self.filename)
-        self.update(dictionary)
-
-    def get_substituted(self, key, path=False):
-        '''
-        Return the specified key from the dict after running string
-        substitutions.
-
-        Parameters
-        -------------
-        path : boolean
-            If True, then after template expansion on the value, it will
-            additionally be treated as a path. If it is relative (does not
-            start with /) then the directory of the JSON file the Config was
-            loaded from will be preprended to it.
-
-        Returns
-        -------------
-        string, number, list, or ConfigDict giving the requested value
-
-        '''
-        value = self[key]
-        result = string.Template(value).substitute(**self.substitutions)
-
-        # If it's an absolute path or a URL, we don't want to change it.
-        if path and not (result.startswith("/") or urlparse(result).scheme):
-            result = os.path.join(self.basedir, result)
-        return result
-
+    return substituted

--- a/variant_calling_benchmarks/guacamole_cluster.py
+++ b/variant_calling_benchmarks/guacamole_cluster.py
@@ -31,8 +31,7 @@ def main(args, config):
     patient_to_vcf = {}
 
     environment_variables = dict(os.environ)
-    for key in config.get("environment_variables", {}):
-        environment_variables[key] = config.get_substituted(key)
+    environment_variables.update(config.get("environment_variables", {}))
 
     for patient in patients:
         out_vcf = os.path.join(
@@ -43,7 +42,7 @@ def main(args, config):
             patient, out_vcf))
 
         invocation = (
-            [config.get_substituted("spark_submit", path=True)] +
+            [config["spark_submit"]] +
             config["spark_submit_arguments"] + 
             ["--jars", args.guacamole_dependencies_jar] +
             ["--class", "org.hammerlab.guacamole.Main", args.guacamole_jar] +

--- a/variant_calling_benchmarks/guacamole_cluster.py
+++ b/variant_calling_benchmarks/guacamole_cluster.py
@@ -16,8 +16,6 @@ from .joint_caller import process_results
 
 parser = argparse.ArgumentParser(description=__doc__)
 common.add_common_run_args(parser)
-parser.add_argument("--spark-submit", default="spark-submit",
-    help="Path to spark-submit script")
 
 def run(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
@@ -32,6 +30,10 @@ def main(args, config):
 
     patient_to_vcf = {}
 
+    environment_variables = dict(os.environ)
+    for key in config.get("environment_variables", {}):
+        environment_variables[key] = config.get_substituted(key)
+
     for patient in patients:
         out_vcf = os.path.join(
             os.path.abspath(args.out_dir),
@@ -41,7 +43,7 @@ def main(args, config):
             patient, out_vcf))
 
         invocation = (
-            [args.spark_submit] +
+            [config.get_substituted("spark_submit", path=True)] +
             config["spark_submit_arguments"] + 
             ["--jars", args.guacamole_dependencies_jar] +
             ["--class", "org.hammerlab.guacamole.Main", args.guacamole_jar] +
@@ -53,6 +55,6 @@ def main(args, config):
         else:
             logging.info("Running guacamole with arguments %s" % str(
                 invocation))
-            subprocess.check_call(invocation)
+            subprocess.check_call(invocation, env=environment_variables)
 
     process_results.write_merged_calls(args, config, patient_to_vcf)

--- a/variant_calling_benchmarks/joint_caller/invoke.py
+++ b/variant_calling_benchmarks/joint_caller/invoke.py
@@ -28,7 +28,7 @@ def make_arguments(config, patient, out_vcf):
     only_somatic = all(
         x['kind'] == 'somatic' for x in config['variants'].values())
     force_call_loci_string = extract_loci_string(patient, [
-        x.get_substituted('path', path=True)
+        x['path']
         for x in config['variants'].values()
     ])
 
@@ -39,7 +39,7 @@ def make_arguments(config, patient, out_vcf):
 
     arguments = ["somatic-joint"]
     arguments.extend(
-        x.get_substituted('path', path=True) for x in reads.values())
+        x['path'] for x in reads.values())
     arguments.extend(
         ["--tissue-types"] + [x['tissue_type'] for x in reads.values()])
     arguments.extend(
@@ -53,13 +53,12 @@ def make_arguments(config, patient, out_vcf):
 
     if 'loci' in patient_dict:
         arguments.append("--loci")
-        arguments.append(patient_dict.get_substituted('loci'))
+        arguments.append(patient_dict['loci'])
 
     arguments.extend([
         "--force-call-loci-file",
         "file://" + os.path.abspath(force_call_loci_path)])
-    arguments.extend(
-        ["--reference-fasta", config.get_substituted("reference", path=True)])
+    arguments.extend(["--reference-fasta", config["reference"]])
     if config.get("reference_fasta_is_partial", "false") == "true":
         arguments.append("--reference-fasta-is-partial")
     arguments.extend(config.get("guacamole_arguments", []))

--- a/variant_calling_benchmarks/joint_caller/process_results.py
+++ b/variant_calling_benchmarks/joint_caller/process_results.py
@@ -55,7 +55,7 @@ def merge_calls_with_others(config, guacamole_calls_df):
     merged = guacamole_calls_df
 
     for (name, info) in config['variants'].items():
-        variant_file = info.get_substituted('path', path=True)
+        variant_file = info['path']
         df = load_benchmark_variants(variant_file)
 
         # Since we load guacamole VCFs with varcode, the contigs will be


### PR DESCRIPTION
* Simplified configuration system. No more special handling of paths: there's just an automatic `THIS_DIR` substitution available that gives the absolute path to the directory of the current JSON file. No more `ConfigDict` object. We now resolve all substitutions when loading the config and return a plain dict.
* spark-submit is now configured in `demeter.json`. May have to update for gcloud.
* Running on a cluster now supports arbitrary environment variables. `demter.json` sets `YARN_CONF_DIR` and `SPARK_HOME`
